### PR TITLE
Make resourceName optional for setting up the localization file

### DIFF
--- a/src/My.Extensions.Localization.Json/Internal/StringLocalizer.cs
+++ b/src/My.Extensions.Localization.Json/Internal/StringLocalizer.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Localization;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace My.Extensions.Localization.Json.Internal
+{
+    internal class StringLocalizer : IStringLocalizer
+    {
+        private IStringLocalizer _localizer;
+
+        public StringLocalizer(IHostingEnvironment env, IStringLocalizerFactory factory)
+        {
+            _localizer = factory.Create(string.Empty, env.ContentRootFileProvider.GetFileInfo("/").PhysicalPath);
+        }
+
+        public LocalizedString this[string name] => _localizer[name];
+
+        public LocalizedString this[string name, params object[] arguments] => _localizer[name, arguments];
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => _localizer.GetAllStrings(includeParentCultures);
+
+        public IStringLocalizer WithCulture(CultureInfo culture) => _localizer.WithCulture(culture);
+    }
+}

--- a/src/My.Extensions.Localization.Json/JsonLocalizationOptions.cs
+++ b/src/My.Extensions.Localization.Json/JsonLocalizationOptions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Localization;
+
+namespace My.Extensions.Localization.Json
+{
+    public class JsonLocalizationOptions : LocalizationOptions
+    {
+        public ResourcesType ResourcesType { get; set; } = ResourcesType.TypeBased;
+    }
+}

--- a/src/My.Extensions.Localization.Json/JsonLocalizationServiceCollectionExtensions.cs
+++ b/src/My.Extensions.Localization.Json/JsonLocalizationServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Localization;
 using My.Extensions.Localization.Json;
+using My.Extensions.Localization.Json.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddJsonLocalization(
            this IServiceCollection services,
-           Action<LocalizationOptions> setupAction)
+           Action<JsonLocalizationOptions> setupAction)
         {
             if (services == null)
             {
@@ -34,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(setupAction));
             }
-
+            
             AddJsonLocalizationServices(services, setupAction);
 
             return services;
@@ -44,11 +45,12 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddSingleton<IStringLocalizerFactory, JsonStringLocalizerFactory>();
             services.TryAddTransient(typeof(IStringLocalizer<>), typeof(StringLocalizer<>));
+            services.TryAddTransient(typeof(IStringLocalizer), typeof(StringLocalizer));
         }
 
         internal static void AddJsonLocalizationServices(
             IServiceCollection services,
-            Action<LocalizationOptions> setupAction)
+            Action<JsonLocalizationOptions> setupAction)
         {
             AddJsonLocalizationServices(services);
             services.Configure(setupAction);

--- a/src/My.Extensions.Localization.Json/JsonStringLocalizer.cs
+++ b/src/My.Extensions.Localization.Json/JsonStringLocalizer.cs
@@ -19,14 +19,22 @@ namespace My.Extensions.Localization.Json
         private readonly ILogger _logger;
 
         private string _searchedLocation;
-
+        
         public JsonStringLocalizer(
             string resourcesPath,
             string resourceName,
             ILogger logger)
         {
             _resourcesPath = resourcesPath ?? throw new ArgumentNullException(nameof(resourcesPath));
-            _resourceName = resourceName;
+            _resourceName = resourceName ?? throw new ArgumentNullException(nameof(resourcesPath));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        internal JsonStringLocalizer(
+            string resourcesPath,
+            ILogger logger)
+        {
+            _resourcesPath = resourcesPath ?? throw new ArgumentNullException(nameof(resourcesPath));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -84,7 +92,12 @@ namespace My.Extensions.Localization.Json
             var culture = CultureInfo.CurrentUICulture;
             var resources = _resourcesCache.GetOrAdd(culture.Name, _ =>
             {
-                var resourceFile = (string.IsNullOrEmpty(_resourceName) ? $"{culture.Name}" : $"{_resourceName}.{culture.Name}") + ".json";
+                var resourceFile = $"{culture.Name}.json";
+                if (_resourceName != null)
+                {
+                    resourceFile = String.Join(".", _resourceName, resourceFile);
+                }
+
                 _searchedLocation = Path.Combine(_resourcesPath, resourceFile);
                 IEnumerable<KeyValuePair<string, string>> value = null;
 

--- a/src/My.Extensions.Localization.Json/JsonStringLocalizer.cs
+++ b/src/My.Extensions.Localization.Json/JsonStringLocalizer.cs
@@ -26,7 +26,7 @@ namespace My.Extensions.Localization.Json
             ILogger logger)
         {
             _resourcesPath = resourcesPath ?? throw new ArgumentNullException(nameof(resourcesPath));
-            _resourceName = resourceName ?? throw new ArgumentNullException(nameof(resourceName));
+            _resourceName = resourceName;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -84,7 +84,7 @@ namespace My.Extensions.Localization.Json
             var culture = CultureInfo.CurrentUICulture;
             var resources = _resourcesCache.GetOrAdd(culture.Name, _ =>
             {
-                var resourceFile = $"{_resourceName}.{culture.Name}.json";
+                var resourceFile = (string.IsNullOrEmpty(_resourceName) ? $"{culture.Name}" : $"{_resourceName}.{culture.Name}") + ".json";
                 _searchedLocation = Path.Combine(_resourcesPath, resourceFile);
                 IEnumerable<KeyValuePair<string, string>> value = null;
 

--- a/src/My.Extensions.Localization.Json/My.Extensions.Localization.Json.csproj
+++ b/src/My.Extensions.Localization.Json/My.Extensions.Localization.Json.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="2.0.0" />

--- a/src/My.Extensions.Localization.Json/ResourcesType.cs
+++ b/src/My.Extensions.Localization.Json/ResourcesType.cs
@@ -1,0 +1,8 @@
+﻿namespace My.Extensions.Localization.Json
+{
+    public enum ResourcesType
+    {
+        CultureBased,
+        TypeBased
+    }
+}


### PR DESCRIPTION
This is to loosen the rule of `resourceName`.
In my solution, I have single localization file for each language (i.e. `en.json`, `ar.json` etc.).