### PR TITLE
Fix System.ArgumentOutOfRangeException for system types

### DIFF
--- a/src/My.Extensions.Localization.Json/JsonStringLocalizerFactory.cs
+++ b/src/My.Extensions.Localization.Json/JsonStringLocalizerFactory.cs
@@ -56,8 +56,8 @@ namespace My.Extensions.Localization.Json
             var assemblyName = resourceSource.Assembly.GetName().Name;
             var typeName = $"{assemblyName}.{typeInfo.Name}" == typeInfo.FullName
                 ? typeInfo.Name
-                : typeInfo.FullName.Substring(assemblyName.Length + 1);
-            
+                : TrimPrefix(typeInfo.FullName, assemblyName + ".");
+
             resourcesPath = Path.Combine(PathHelpers.GetApplicationRoot(), GetResourcePath(assembly));
             typeName = TryFixInnerClassPath(typeName);
 

--- a/test/My.Extensions.Localization.Json.Tests/JsonStringLocalizerFactoryTests.cs
+++ b/test/My.Extensions.Localization.Json.Tests/JsonStringLocalizerFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -41,6 +42,22 @@ namespace My.Extensions.Localization.Json.Tests
             // Assert
             Assert.NotNull(localizer);
             Assert.Equal("Bonjour", localizer["Hello"]);
+        }
+
+        [Fact]
+        public void JsonStringLocalizerFactory_CreateLocalizerWithSystemType()
+        {
+            SetupLocalizationOptions("Resources");
+            LocalizationHelper.SetCurrentCulture("fr-FR");
+
+            // Arrange
+            var localizerFactory = new JsonStringLocalizerFactory(_localizationOptions.Object, _loggerFactory);
+
+            // Act
+            var localizer = localizerFactory.Create(typeof(string));
+
+            // Assert
+            // Should not throw an exception
         }
 
         [Theory]

--- a/test/My.Extensions.Localization.Json.Tests/JsonStringLocalizerFactoryTests.cs
+++ b/test/My.Extensions.Localization.Json.Tests/JsonStringLocalizerFactoryTests.cs
@@ -44,8 +44,10 @@ namespace My.Extensions.Localization.Json.Tests
             Assert.Equal("Bonjour", localizer["Hello"]);
         }
 
-        [Fact]
-        public void JsonStringLocalizerFactory_CreateLocalizerWithSystemType()
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(Test))]
+        public void CreateLocalizerWithTypeSucceeds(Type type)
         {
             SetupLocalizationOptions("Resources");
             LocalizationHelper.SetCurrentCulture("fr-FR");
@@ -54,7 +56,7 @@ namespace My.Extensions.Localization.Json.Tests
             var localizerFactory = new JsonStringLocalizerFactory(_localizationOptions.Object, _loggerFactory);
 
             // Act
-            var localizer = localizerFactory.Create(typeof(string));
+            localizerFactory.Create(type);
 
             // Assert
             // Should not throw an exception


### PR DESCRIPTION
@hishamco I encountered the same problem as stated in #63. When creating the stringlocalizer from the factory, it tries to remove the assembly name from the type name. However, some types their typename does not contain the assembly name. This is solved by trimprefixing the assembly from the full type name. If typename does not contain the assembly, the entire typename is used instead.

I also added a test for this.

What do you think?

