### PR TITLE
skip json comment and allow trailing commas

### DIFF
--- a/src/My.Extensions.Localization.Json/Internal/JsonResourceManager.cs
+++ b/src/My.Extensions.Localization.Json/Internal/JsonResourceManager.cs
@@ -27,7 +27,7 @@ namespace My.Extensions.Localization.Json.Internal
         {
             TryLoadResourceSet(culture);
 
-            if(!_resourcesCache.ContainsKey(culture.Name))
+            if (!_resourcesCache.ContainsKey(culture.Name))
             {
                 return null;
             }
@@ -37,7 +37,7 @@ namespace My.Extensions.Localization.Json.Internal
                 var allResources = new ConcurrentDictionary<string, string>();
                 do
                 {
-                    if(_resourcesCache.TryGetValue(culture.Name, out ConcurrentDictionary<string, string> resources))
+                    if (_resourcesCache.TryGetValue(culture.Name, out ConcurrentDictionary<string, string> resources))
                     {
                         foreach (var entry in resources)
                         {
@@ -123,7 +123,7 @@ namespace My.Extensions.Localization.Json.Internal
                     if (resourceFiles.Count() == 0)
                     {
                         resourceFiles = GetResourceFiles(rootCulture);
-                    }              
+                    }
                 }
                 else
                 {
@@ -135,9 +135,9 @@ namespace My.Extensions.Localization.Json.Internal
                     var resources = LoadJsonResources(file);
                     var fileName = Path.GetFileNameWithoutExtension(file);
                     var cultureName = fileName.Substring(fileName.LastIndexOf(".") + 1);
-                    
+
                     culture = CultureInfo.GetCultureInfo(cultureName);
-                    
+
                     if (_resourcesCache.ContainsKey(culture.Name))
                     {
                         foreach (var resource in resources)
@@ -148,7 +148,7 @@ namespace My.Extensions.Localization.Json.Internal
                     else
                     {
                         _resourcesCache.TryAdd(culture.Name, new ConcurrentDictionary<string, string>(resources.ToDictionary(r => r.Key, r => r.Value)));
-                    }                 
+                    }
                 }
             }
 
@@ -178,9 +178,15 @@ namespace My.Extensions.Localization.Json.Internal
             var resources = new Dictionary<string, string>();
             if (File.Exists(filePath))
             {
-                var reader = new StreamReader(filePath);
+                var documentOptions = new JsonDocumentOptions
+                {
+                    CommentHandling = JsonCommentHandling.Skip,
+                    AllowTrailingCommas = true,
+                };
 
-                var document = JsonDocument.Parse(reader.BaseStream);
+                using var reader = new StreamReader(filePath);
+
+                using var document = JsonDocument.Parse(reader.BaseStream, documentOptions);
 
                 resources = document.RootElement.EnumerateObject().ToDictionary(e => e.Name, e => e.Value.ToString());
             }

--- a/src/My.Extensions.Localization.Json/Internal/JsonResourceManager.cs
+++ b/src/My.Extensions.Localization.Json/Internal/JsonResourceManager.cs
@@ -9,6 +9,12 @@ namespace My.Extensions.Localization.Json.Internal
 {
     public class JsonResourceManager
     {
+        private static readonly JsonDocumentOptions _jsonDocumentOptions = new JsonDocumentOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+
         private ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _resourcesCache = new ConcurrentDictionary<string, ConcurrentDictionary<string, string>>();
 
         public JsonResourceManager(string resourcesPath, string resourceName = null)
@@ -178,15 +184,9 @@ namespace My.Extensions.Localization.Json.Internal
             var resources = new Dictionary<string, string>();
             if (File.Exists(filePath))
             {
-                var documentOptions = new JsonDocumentOptions
-                {
-                    CommentHandling = JsonCommentHandling.Skip,
-                    AllowTrailingCommas = true,
-                };
-
                 using var reader = new StreamReader(filePath);
 
-                using var document = JsonDocument.Parse(reader.BaseStream, documentOptions);
+                using var document = JsonDocument.Parse(reader.BaseStream, _jsonDocumentOptions);
 
                 resources = document.RootElement.EnumerateObject().ToDictionary(e => e.Name, e => e.Value.ToString());
             }

--- a/test/My.Extensions.Localization.Json.Tests/JsonStringLocalizerTests.cs
+++ b/test/My.Extensions.Localization.Json.Tests/JsonStringLocalizerTests.cs
@@ -86,6 +86,23 @@ namespace My.Extensions.Localization.Json.Tests
             Assert.Equal(expected, translation);
         }
 
+
+        [Theory]
+        [InlineData("zh-CN", "Hello", "你好")]
+        [InlineData("zh-CN", "Hello, {0}", "你好，{0}")]
+        public void GetTranslationWithCommentsOrCommas(string culture, string name, string expected)
+        {
+            // Arrange
+            string translation = null;
+
+            // Act
+            LocalizationHelper.SetCurrentCulture(culture);
+            translation = _localizer[name];
+
+            // Assert
+            Assert.Equal(expected, translation);
+        }
+
         [Fact]
         public void GetTranslation_StronglyTypeResourceName()
         {

--- a/test/My.Extensions.Localization.Json.Tests/My.Extensions.Localization.Json.Tests.csproj
+++ b/test/My.Extensions.Localization.Json.Tests/My.Extensions.Localization.Json.Tests.csproj
@@ -21,6 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Resources\Common\Test.zh.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\JsonStringLocalizerFactoryTests.Model.ar.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/My.Extensions.Localization.Json.Tests/Resources/Common/Test.zh.json
+++ b/test/My.Extensions.Localization.Json.Tests/Resources/Common/Test.zh.json
@@ -1,0 +1,6 @@
+﻿// This is a Chinese json file
+{
+  "Hello": "你好",
+  // The tail has a comma
+  "Hello, {0}": "你好，{0}",
+}


### PR DESCRIPTION
like this:
```json
{
  // it's a comment
  "HelloWorld": "Hello，World!",
}

```